### PR TITLE
skip metadata._typeorm_migrations if they don't exist

### DIFF
--- a/packages/twenty-server/src/database/commands/upgrade-version-command/0-53/0-53-copy-typeorm-migrations.command.ts
+++ b/packages/twenty-server/src/database/commands/upgrade-version-command/0-53/0-53-copy-typeorm-migrations.command.ts
@@ -38,6 +38,21 @@ export class CopyTypeormMigrationsCommand extends MigrationCommandRunner {
       await queryRunner.connect();
       await queryRunner.startTransaction();
 
+      // Check if metadata._typeorm_migrations table exists
+      const tableExists = await queryRunner.query(
+        `SELECT EXISTS (
+          SELECT FROM information_schema.tables 
+          WHERE table_schema = 'metadata' 
+          AND table_name = '_typeorm_migrations'
+        )`,
+      );
+
+      if (!tableExists[0].exists) {
+        this.logger.log('metadata._typeorm_migrations table does not exist, skipping migration');
+        await queryRunner.commitTransaction();
+        return;
+      }
+
       const metadataMigrations = await queryRunner.query(
         'SELECT * FROM metadata._typeorm_migrations ORDER BY id ASC',
       );


### PR DESCRIPTION
I am seeing an issue where this migrations fails because the `metadata._typeorm_migrations` table does not exist.

```pgsql
copy _typeorm_migrations from metadata to core
query failed: SELECT * FROM metadata._typeorm_migrations ORDER BY id ASC
error: error: relation "metadata._typeorm_migrations" does not exist
[Nest] 430  - 06/01/2025, 10:22:35 PM   ERROR [CopyTypeormMigrationsCommand] Failed to copy migrations: relation "metadata._typeorm_migrations" does not exist
[Nest] 430  - 06/01/2025, 10:22:35 PM   ERROR [CopyTypeormMigrationsCommand] undefined
[Nest] 430  - 06/01/2025, 10:22:35 PM   ERROR [DatabaseMigrationService] Error running database migrations:
[Nest] 430  - 06/01/2025, 10:22:35 PM   ERROR [DatabaseMigrationService] QueryFailedError: relation "metadata._typeorm_migrations" does not exist
[Nest] 430  - 06/01/2025, 10:22:35 PM   ERROR [UpgradeCommand] Command failed
[Nest] 430  - 06/01/2025, 10:22:35 PM   ERROR [UpgradeCommand] undefined
[Nest] 430  - 06/01/2025, 10:22:35 PM     LOG [UpgradeCommand] Command completed!
[Nest] 430  - 06/01/2025, 10:22:35 PM   ERROR [QueryFailedError] relation "metadata._typeorm_migrations" does not exist
```

I _think_ this table is not meant to exist anymore - which means that anyone who is onboarding into the project will run into an issue unless we handle the case where the table doesn't exist.

We need to handle both the existing case and the non existing case to support people who _do_ have metadata._typeorm_migrations` to migrate.