### PR TITLE
getRabbitSignDownloadUrl endpoint

### DIFF
--- a/packages/twenty-server/src/modules/rabbitsign/rabbitsign.resolver.ts
+++ b/packages/twenty-server/src/modules/rabbitsign/rabbitsign.resolver.ts
@@ -1,7 +1,9 @@
 import { UseGuards } from '@nestjs/common';
-import { Args, Mutation, Resolver } from '@nestjs/graphql';
+import { Args, Mutation, Query, Resolver } from '@nestjs/graphql';
 import { FileService } from 'src/engine/core-modules/file/services/file.service';
+import { User } from 'src/engine/core-modules/user/user.entity';
 import { Workspace } from 'src/engine/core-modules/workspace/workspace.entity';
+import { AuthUser } from 'src/engine/decorators/auth/auth-user.decorator';
 import { AuthWorkspace } from 'src/engine/decorators/auth/auth-workspace.decorator';
 import { WorkspaceAuthGuard } from 'src/engine/guards/workspace-auth.guard';
 import { CreateOneRabbitSignSignatureInput } from 'src/modules/rabbitsign/dtos/create-one-rabbit-sign-signature.input';
@@ -71,5 +73,30 @@ export class RabbitSignResolver {
     return {
       id: signature.id,
     };
+  }
+
+  @Query(() => String, {
+    name: 'getRabbitSignDownloadUrl',
+    description: 'Get the download URL for a completed RabbitSign signature',
+  })
+  async getRabbitSignDownloadUrl(
+    @Args('signatureId') signatureId: string,
+    @AuthWorkspace() workspace: Workspace,
+    @AuthUser() user: User,
+  ): Promise<string | null> {
+    const workspaceId = workspace.id;
+    
+    // Get the workspace member ID for the current user in this workspace
+    const workspaceMemberId = user.workspaceMember?.id;
+    
+    if (!workspaceMemberId) {
+      throw new Error('User is not a member of this workspace');
+    }
+    
+    return await this.rabbitSignSignatureService.getDownloadUrl(
+      workspaceId,
+      workspaceMemberId,
+      signatureId,
+    );
   }
 }

--- a/packages/twenty-server/src/modules/rabbitsign/rabbitsignsignature.service.ts
+++ b/packages/twenty-server/src/modules/rabbitsign/rabbitsignsignature.service.ts
@@ -101,8 +101,6 @@ export class RabbitSignSignatureService extends TypeOrmQueryService<RabbitSignSi
           // You might want to store additional info like folder ID
         }
       );
-      console.log('banana')
-      console.log('result', result);
 
       return {
         ...signatureRecord,
@@ -359,6 +357,51 @@ export class RabbitSignSignatureService extends TypeOrmQueryService<RabbitSignSi
       );
 
       console.log(`Signature ${signatureId} marked as completed - all signers have signed`);
+    }
+  }
+
+  /**
+   * Get download URL for a completed signature
+   */
+  async getDownloadUrl(
+    workspaceId: string,
+    workspaceMemberId: string,
+    signatureId: string,
+  ): Promise<string | null> {
+    console.log(`Getting repository for workspace ${workspaceId} to fetch signature ${signatureId}`);
+    const rabbitSignSignatureRepository = 
+      await this.twentyORMGlobalManager.getRepositoryForWorkspace<RabbitSignSignatureWorkspaceEntity>(
+        workspaceId,
+        'rabbitSignSignature',
+      );
+
+    const signature = await rabbitSignSignatureRepository.findOne({
+      where: { id: signatureId, workspaceMemberId },
+    });
+
+    if (!signature || !signature.folderId) {
+      return null;
+    }
+
+    try {
+      const rabbitSignKey = await this.rabbitSignKeyService.getRabbitSignKeyForWorkspace(workspaceMemberId, workspaceId);
+      const { keyId, keySecret } = rabbitSignKey;
+
+      const path = `/api/v1/folder/${signature.folderId}`;
+      const headers = this.createSignatureHeaders('GET', path, keyId, keySecret);
+
+      console.log('before axios')
+      const response = await axios.get(
+        `${this.RABBITSIGN_API_BASE_URL}/folder/${signature.folderId}`,
+        { headers }
+      );
+      console.log('after axios')
+      console.log(response.data)
+
+      return response.data.downloadUrl || null;
+    } catch (error) {
+      console.error('Failed to get download URL:', error);
+      return null;
     }
   }
 }


### PR DESCRIPTION
After an attachment is signed, we can use this url to fetch the signed document from Rabbit.  