### PR TITLE
Extract rabbit files to s3

### DIFF
--- a/packages/twenty-server/src/engine/workspace-manager/workspace-sync-metadata/constants/standard-field-ids.ts
+++ b/packages/twenty-server/src/engine/workspace-manager/workspace-sync-metadata/constants/standard-field-ids.ts
@@ -53,6 +53,8 @@ export const ATTACHMENT_STANDARD_FIELD_IDS = {
   opportunity: '20202020-7374-499d-bea3-9354890755b5',
   custom: '20202020-302d-43b3-9aea-aa4f89282a9f',
   signature: '20202020-6d1e-51ac-b15b-621631238d86',
+  signatureAuditTrail: '20202020-7d1e-51ac-b15b-121631238d87',
+  signatureSigned: '20202020-8d1e-51ac-b15b-221631238d88',
 };
 
 export const BASE_OBJECT_STANDARD_FIELD_IDS = {
@@ -658,6 +660,8 @@ export const RABBIT_SIGN_SIGNATURE_STANDARD_FIELD_IDS = {
   attachment: '20202020-5d1e-51ac-b13b-621633238d85',
   folderId: '20202020-5d1e-51ac-b13b-621633238c25',
   signers: '20202020-6d1e-51ac-b13b-621633234c86',
+  signatureAuditTrailAttachment: '20202020-7d1e-51ac-b13b-121633234c87',
+  signatureSignedAttachment: '20202020-8d1e-51ac-b13b-221633234c88',
 };
 
 export const RABBIT_SIGN_SIGNER_STANDARD_FIELD_IDS = {

--- a/packages/twenty-server/src/modules/attachment/standard-objects/attachment.workspace-entity.ts
+++ b/packages/twenty-server/src/modules/attachment/standard-objects/attachment.workspace-entity.ts
@@ -192,6 +192,38 @@ export class AttachmentWorkspaceEntity extends BaseWorkspaceEntity {
   @WorkspaceJoinColumn('signature')
   signatureId: string | null;
 
+  @WorkspaceRelation({
+    standardId: ATTACHMENT_STANDARD_FIELD_IDS.signatureAuditTrail,
+    type: RelationType.MANY_TO_ONE,
+    label: msg`Signature Audit Trail Download`,
+    description: msg`Attachment signature audit trail download`,
+    icon: 'IconFileDownload',
+    inverseSideTarget: () => RabbitSignSignatureWorkspaceEntity,
+    inverseSideFieldKey: 'signatureAuditTrailDownloadAttachment',
+    onDelete: RelationOnDeleteAction.SET_NULL,
+  })
+  @WorkspaceIsNullable()
+  signatureAuditTrailDownload: Relation<RabbitSignSignatureWorkspaceEntity> | null;
+
+  @WorkspaceJoinColumn('signatureAuditTrailDownload')
+  signatureAuditTrailDownloadId: string | null;
+
+  @WorkspaceRelation({
+    standardId: ATTACHMENT_STANDARD_FIELD_IDS.signatureSigned,
+    type: RelationType.MANY_TO_ONE,
+    label: msg`Signature Signed`,
+    description: msg`Attachment signature signed`,
+    icon: 'IconFileCheck',
+    inverseSideTarget: () => RabbitSignSignatureWorkspaceEntity,
+    inverseSideFieldKey: 'signatureSignedAttachment',
+    onDelete: RelationOnDeleteAction.SET_NULL,
+  })
+  @WorkspaceIsNullable()
+  signatureSigned: Relation<RabbitSignSignatureWorkspaceEntity> | null;
+
+  @WorkspaceJoinColumn('signatureSigned')
+  signatureSignedId: string | null;
+
   @WorkspaceDynamicRelation({
     type: RelationType.MANY_TO_ONE,
     argsFactory: (oppositeObjectMetadata) => ({

--- a/packages/twenty-server/src/modules/rabbitsign/rabbitsign.module.ts
+++ b/packages/twenty-server/src/modules/rabbitsign/rabbitsign.module.ts
@@ -1,6 +1,8 @@
+import { HttpModule } from '@nestjs/axios';
 import { Module } from '@nestjs/common';
 import { JwtService } from '@nestjs/jwt';
 import { DomainManagerModule } from 'src/engine/core-modules/domain-manager/domain-manager.module';
+import { FileUploadService } from 'src/engine/core-modules/file/file-upload/services/file-upload.service';
 import { FileService } from 'src/engine/core-modules/file/services/file.service';
 import { JwtWrapperService } from 'src/engine/core-modules/jwt/services/jwt-wrapper.service';
 import { WorkspaceRepository } from 'src/engine/twenty-orm/repository/workspace.repository';
@@ -16,6 +18,7 @@ import { RabbitSignSignerService } from './rabbitsignsigner.service';
 @Module({
   imports: [
     DomainManagerModule,
+    HttpModule,
   ],
   controllers: [RabbitSignWebhookController],
   providers: [
@@ -30,6 +33,7 @@ import { RabbitSignSignerService } from './rabbitsignsigner.service';
     RabbitSignSignerService,
     RabbitSignResolver,
     WorkspaceRepository,
+    FileUploadService,
   ],
   exports: [
     CreateOneRabbitSignSignatureInput,

--- a/packages/twenty-server/src/modules/rabbitsign/rabbitsignsignature.service.ts
+++ b/packages/twenty-server/src/modules/rabbitsign/rabbitsignsignature.service.ts
@@ -396,6 +396,22 @@ export class RabbitSignSignatureService extends TypeOrmQueryService<RabbitSignSi
       throw new Error('Signature not found or no folder ID available');
     }
 
+    // Get the original attachment to copy its fields
+    const attachmentRepository = await this.twentyORMGlobalManager.getRepositoryForWorkspace<AttachmentWorkspaceEntity>(
+      workspaceId,
+      'attachment',
+    );
+
+    const originalAttachment = await attachmentRepository.findOne({
+      where: { signatureId: signatureId },
+    });
+
+    if (!originalAttachment) {
+      throw new Error('Original attachment not found for signature');
+    }
+
+    console.log(`Found original attachment: ${originalAttachment.name} with personId: ${originalAttachment.personId}, companyId: ${originalAttachment.companyId}`);
+
     try {
       // Step 1: Get download URL from RabbitSign
       const rabbitSignKey = await this.rabbitSignKeyService.getRabbitSignKeyForWorkspace(signature.workspaceMemberId, workspaceId);
@@ -556,11 +572,6 @@ export class RabbitSignSignatureService extends TypeOrmQueryService<RabbitSignSi
       }
 
       // Step 4: Upload each document to S3 and create attachment records
-      const attachmentRepository = await this.twentyORMGlobalManager.getRepositoryForWorkspace<AttachmentWorkspaceEntity>(
-        workspaceId,
-        'attachment',
-      );
-
       const uploadedAttachments: Array<{ id: string; name: string; fullPath: string; type: string }> = [];
 
       for (const file of extractedFiles) {
@@ -584,6 +595,13 @@ export class RabbitSignSignatureService extends TypeOrmQueryService<RabbitSignSi
             type: file.type,
             authorId: signature.workspaceMemberId,
             signatureId: signatureId,
+            // Copy the fields from the original attachment to link to the same person/company
+            personId: originalAttachment.personId,
+            companyId: originalAttachment.companyId,
+            policyId: originalAttachment.policyId,
+            taskId: originalAttachment.taskId,
+            noteId: originalAttachment.noteId,
+            opportunityId: originalAttachment.opportunityId,
           });
 
           uploadedAttachments.push({

--- a/packages/twenty-server/src/modules/rabbitsign/rabbitsignsignature.service.ts
+++ b/packages/twenty-server/src/modules/rabbitsign/rabbitsignsignature.service.ts
@@ -2,9 +2,13 @@ import { Injectable } from '@nestjs/common';
 import { TypeOrmQueryService } from '@ptc-org/nestjs-query-typeorm';
 import axios from 'axios';
 import { createHash } from 'crypto';
+import { FileUploadService } from 'src/engine/core-modules/file/file-upload/services/file-upload.service';
+import { FileFolder } from 'src/engine/core-modules/file/interfaces/file-folder.interface';
 import { TwentyORMGlobalManager } from 'src/engine/twenty-orm/twenty-orm-global.manager';
 import { AttachmentWorkspaceEntity } from 'src/modules/attachment/standard-objects/attachment.workspace-entity';
 import { RabbitSignKeyService } from 'src/modules/rabbitsign/rabbitsignkey.service';
+import { Extract, Open } from 'unzipper';
+import { v4 as uuidv4 } from 'uuid';
 import { RabbitSignSignerService } from './rabbitsignsigner.service';
 import { RabbitSignSignatureWorkspaceEntity } from './standard-objects/rabbitsignsignature.workplace-entity';
 
@@ -33,6 +37,7 @@ export class RabbitSignSignatureService extends TypeOrmQueryService<RabbitSignSi
     private readonly twentyORMGlobalManager: TwentyORMGlobalManager,
     private readonly rabbitSignKeyService: RabbitSignKeyService,
     private readonly rabbitSignSignerService: RabbitSignSignerService,
+    private readonly fileUploadService: FileUploadService,
   ) {
     super(null as any);
   }
@@ -356,12 +361,300 @@ export class RabbitSignSignatureService extends TypeOrmQueryService<RabbitSignSi
         { signatureStatus: 'COMPLETED' },
       );
 
+
+      // In your webhook handler
+      await this.processSignatureDocuments(
+        workspaceId,
+        signatureId
+      );
+
       console.log(`Signature ${signatureId} marked as completed - all signers have signed`);
     }
   }
 
   /**
-   * Get download URL for a completed signature
+   * Process signature documents by downloading the zip from RabbitSign,
+   * extracting the documents, uploading them to S3, and creating attachment records
+   */
+  async processSignatureDocuments(
+    workspaceId: string,
+    signatureId: string,
+  ): Promise<Array<{ id: string; name: string; fullPath: string; type: string }>> {
+    console.log(`Processing signature documents for signature ${signatureId} in workspace ${workspaceId}`);
+    
+    const rabbitSignSignatureRepository = 
+      await this.twentyORMGlobalManager.getRepositoryForWorkspace<RabbitSignSignatureWorkspaceEntity>(
+        workspaceId,
+        'rabbitSignSignature',
+      );
+
+    const signature = await rabbitSignSignatureRepository.findOne({
+      where: { id: signatureId },
+    });
+
+    if (!signature || !signature.folderId) {
+      throw new Error('Signature not found or no folder ID available');
+    }
+
+    try {
+      // Step 1: Get download URL from RabbitSign
+      const rabbitSignKey = await this.rabbitSignKeyService.getRabbitSignKeyForWorkspace(signature.workspaceMemberId, workspaceId);
+      const { keyId, keySecret } = rabbitSignKey;
+
+      const path = `/api/v1/folder/${signature.folderId}`;
+      const headers = this.createSignatureHeaders('GET', path, keyId, keySecret);
+
+      const response = await axios.get(
+        `${this.RABBITSIGN_API_BASE_URL}/folder/${signature.folderId}`,
+        { headers }
+      );
+
+      const downloadUrl = response.data.downloadUrl;
+      if (!downloadUrl) {
+        throw new Error('No download URL available from RabbitSign');
+      }
+
+      // Step 2: Download the zip file
+      console.log(`Downloading zip from RabbitSign: ${downloadUrl}`);
+      const zipResponse = await axios.get(downloadUrl, {
+        responseType: 'arraybuffer',
+      });
+
+      const zipBuffer = Buffer.from(zipResponse.data);
+      console.log(`Downloaded zip file size: ${zipBuffer.length} bytes`);
+      
+      // Validate that we have a valid zip file
+      if (zipBuffer.length < 4 || zipBuffer.toString('hex', 0, 4) !== '504b0304') {
+        throw new Error('Downloaded file does not appear to be a valid ZIP file');
+      }
+      
+      // Log the first few bytes for debugging
+      console.log(`Zip file header: ${zipBuffer.toString('hex', 0, 16)}`);
+
+      // Step 3: Extract documents from zip
+      const extractedFiles: Array<{ name: string; buffer: Buffer; type: string }> = [];
+      
+      try {
+        console.log('Starting zip extraction using buffer method...');
+        
+        // Use the Open.buffer method instead of streaming
+        const directory = await Open.buffer(zipBuffer);
+        
+        console.log('Directory entries:', directory.files.length);
+        
+        for (const entry of directory.files) {
+          console.log('Processing entry:', entry.path, entry.type);
+          
+          // Skip directories and hidden files
+          if (entry.type === 'Directory' || entry.path.startsWith('.') || entry.path.endsWith('/')) {
+            console.log(`Skipping directory or hidden file: ${entry.path}`);
+            continue;
+          }
+          
+          try {
+            const buffer = await entry.buffer();
+            const fileType = this.getFileTypeFromName(entry.path);
+            console.log(`Extracted file: ${entry.path} (${buffer.length} bytes)`);
+            
+            extractedFiles.push({
+              name: entry.path,
+              buffer: buffer,
+              type: fileType,
+            });
+          } catch (entryError) {
+            console.error(`Error extracting file ${entry.path}:`, entryError);
+            // Continue with other files
+          }
+        }
+        
+        console.log(`Zip extraction completed. Found ${extractedFiles.length} files.`);
+        
+      } catch (extractionError) {
+        console.error('Failed to extract zip using buffer method:', extractionError);
+        
+        // Fallback: Try the original streaming approach as a last resort
+        console.log('Trying streaming approach as fallback...');
+        
+        await new Promise<void>((resolve, reject) => {
+          const stream = require('stream');
+          const bufferStream = new stream.PassThrough();
+          
+          // Set up error handling for the buffer stream
+          bufferStream.on('error', (error: any) => {
+            console.error('Buffer stream error:', error);
+            reject(error);
+          });
+          
+          bufferStream.end(zipBuffer);
+
+          const extractStream = Extract();
+          
+          // Set a timeout for the extraction process
+          const timeout = setTimeout(() => {
+            console.error('Zip extraction timed out after 30 seconds');
+            reject(new Error('Zip extraction timed out'));
+          }, 30000);
+          
+          extractStream.on('entry', (entry: any) => {
+            console.log('Processing entry:', {
+              path: entry.path,
+              type: entry.type,
+              size: entry.vars?.uncompressedSize
+            });
+            
+            // Check if entry has a valid path
+            if (!entry.path) {
+              console.warn('Entry has no path, skipping');
+              entry.autodrain();
+              return;
+            }
+            
+            const fileName = entry.path;
+            const fileType = this.getFileTypeFromName(fileName);
+            
+            // Skip directories and hidden files
+            if (entry.type === 'Directory' || fileName.startsWith('.')) {
+              console.log(`Skipping directory or hidden file: ${fileName}`);
+              entry.autodrain();
+              return;
+            }
+
+            const chunks: Buffer[] = [];
+            entry.on('data', (chunk: Buffer) => chunks.push(chunk));
+            entry.on('end', () => {
+              const fileBuffer = Buffer.concat(chunks);
+              console.log(`Extracted file: ${fileName} (${fileBuffer.length} bytes)`);
+              extractedFiles.push({
+                name: fileName,
+                buffer: fileBuffer,
+                type: fileType,
+              });
+            });
+            entry.on('error', (error: any) => {
+              console.error(`Error processing entry ${fileName}:`, error);
+              clearTimeout(timeout);
+              reject(error);
+            });
+          })
+          .on('end', () => {
+            clearTimeout(timeout);
+            console.log(`Zip extraction completed. Found ${extractedFiles.length} files.`);
+            resolve();
+          })
+          .on('error', (error: any) => {
+            clearTimeout(timeout);
+            console.error('Error during zip extraction:', error);
+            reject(error);
+          });
+
+          bufferStream.pipe(extractStream);
+        });
+      }
+
+      if (extractedFiles.length === 0) {
+        throw new Error('No files found in the zip archive');
+      }
+
+      // Step 4: Upload each document to S3 and create attachment records
+      const attachmentRepository = await this.twentyORMGlobalManager.getRepositoryForWorkspace<AttachmentWorkspaceEntity>(
+        workspaceId,
+        'attachment',
+      );
+
+      const uploadedAttachments: Array<{ id: string; name: string; fullPath: string; type: string }> = [];
+
+      for (const file of extractedFiles) {
+        try {
+          // Generate a unique filename to avoid conflicts
+          const uniqueFilename = `${uuidv4()}_${file.name}`;
+          
+          // Upload to S3
+          const uploadResult = await this.fileUploadService.uploadFile({
+            file: file.buffer,
+            filename: uniqueFilename,
+            mimeType: this.getMimeType(file.type),
+            fileFolder: FileFolder.Attachment,
+            workspaceId,
+          });
+
+          // Create attachment record
+          const attachment = await attachmentRepository.save({
+            name: file.name,
+            fullPath: uploadResult.files[0].path,
+            type: file.type,
+            authorId: signature.workspaceMemberId,
+            signatureId: signatureId,
+          });
+
+          uploadedAttachments.push({
+            id: attachment.id,
+            name: file.name,
+            fullPath: uploadResult.files[0].path,
+            type: file.type,
+          });
+
+          console.log(`Successfully uploaded and created attachment for: ${file.name}`);
+        } catch (error) {
+          console.error(`Failed to process file ${file.name}:`, error);
+          // Continue with other files even if one fails
+        }
+      }
+
+      if (uploadedAttachments.length === 0) {
+        throw new Error('Failed to upload any documents from the signature');
+      }
+
+      console.log(`Successfully processed ${uploadedAttachments.length} documents for signature ${signatureId}`);
+      return uploadedAttachments;
+
+    } catch (error) {
+      console.error('Failed to process signature documents:', error);
+      throw new Error(
+        `Failed to process signature documents: ${error?.response?.data?.message || error?.message || 'Unknown error'}`
+      );
+    }
+  }
+
+  /**
+   * Get file type from filename
+   */
+  private getFileTypeFromName(filename: string): string {
+    const extension = filename.split('.').pop()?.toLowerCase();
+    
+    switch (extension) {
+      case 'pdf':
+        return 'application/pdf';
+      case 'doc':
+        return 'application/msword';
+      case 'docx':
+        return 'application/vnd.openxmlformats-officedocument.wordprocessingml.document';
+      case 'png':
+        return 'image/png';
+      case 'jpg':
+      case 'jpeg':
+        return 'image/jpeg';
+      case 'txt':
+        return 'text/plain';
+      default:
+        return 'application/octet-stream';
+    }
+  }
+
+  /**
+   * Get MIME type from file type
+   */
+  private getMimeType(fileType: string): string {
+    // If fileType is already a MIME type, return it
+    if (fileType.includes('/')) {
+      return fileType;
+    }
+    
+    // Otherwise, convert file extension to MIME type
+    return this.getFileTypeFromName(`file.${fileType}`);
+  }
+
+  /**
+   * Get download URL for a completed signature (deprecated - use processSignatureDocuments instead)
    */
   async getDownloadUrl(
     workspaceId: string,

--- a/packages/twenty-server/src/modules/rabbitsign/rabbitsignsignature.service.ts
+++ b/packages/twenty-server/src/modules/rabbitsign/rabbitsignsignature.service.ts
@@ -592,7 +592,7 @@ export class RabbitSignSignatureService extends TypeOrmQueryService<RabbitSignSi
           const attachment = await attachmentRepository.save({
             name: file.name,
             fullPath: uploadResult.files[0].path,
-            type: file.type,
+            type: originalAttachment.type,
             authorId: signature.workspaceMemberId,
             signatureId: signatureId,
             // Copy the fields from the original attachment to link to the same person/company

--- a/packages/twenty-server/src/modules/rabbitsign/rabbitsignsignature.service.ts
+++ b/packages/twenty-server/src/modules/rabbitsign/rabbitsignsignature.service.ts
@@ -573,6 +573,8 @@ export class RabbitSignSignatureService extends TypeOrmQueryService<RabbitSignSi
 
       // Step 4: Upload each document to S3 and create attachment records
       const uploadedAttachments: Array<{ id: string; name: string; fullPath: string; type: string }> = [];
+      let auditTrailAttachment: any = null;
+      let signedAttachment: any = null;
 
       for (const file of extractedFiles) {
         try {
@@ -587,6 +589,10 @@ export class RabbitSignSignatureService extends TypeOrmQueryService<RabbitSignSi
             fileFolder: FileFolder.Attachment,
             workspaceId,
           });
+
+          // Determine if this is the audit trail or signed document based on filename
+          const isAuditTrail = file.name.startsWith('Audit Trail_');
+          const isSignedDocument = !isAuditTrail; // The other file is the signed document
 
           // Create attachment record
           const attachment = await attachmentRepository.save({
@@ -604,6 +610,23 @@ export class RabbitSignSignatureService extends TypeOrmQueryService<RabbitSignSi
             opportunityId: originalAttachment.opportunityId,
           });
 
+          // Store the appropriate attachment based on type
+          if (isAuditTrail) {
+            auditTrailAttachment = attachment;
+            // Link audit trail attachment to signature
+            await attachmentRepository.update(
+              { id: attachment.id },
+              { signatureAuditTrailDownloadId: signatureId }
+            );
+          } else if (isSignedDocument) {
+            signedAttachment = attachment;
+            // Link signed attachment to signature
+            await attachmentRepository.update(
+              { id: attachment.id },
+              { signatureSignedId: signatureId }
+            );
+          }
+
           uploadedAttachments.push({
             id: attachment.id,
             name: file.name,
@@ -611,11 +634,29 @@ export class RabbitSignSignatureService extends TypeOrmQueryService<RabbitSignSi
             type: file.type,
           });
 
-          console.log(`Successfully uploaded and created attachment for: ${file.name}`);
+          console.log(`Successfully uploaded and created attachment for: ${file.name} (${isAuditTrail ? 'audit trail' : isSignedDocument ? 'signed document' : 'other'})`);
         } catch (error) {
           console.error(`Failed to process file ${file.name}:`, error);
           // Continue with other files even if one fails
         }
+      }
+
+      // Update the signature record with the specific attachment references
+      if (auditTrailAttachment || signedAttachment) {
+        const updateData: any = {};
+        if (auditTrailAttachment) {
+          updateData.signatureAuditTrailDownloadAttachmentId = auditTrailAttachment.id;
+        }
+        if (signedAttachment) {
+          updateData.signatureSignedAttachmentId = signedAttachment.id;
+        }
+
+        await rabbitSignSignatureRepository.update(
+          { id: signatureId },
+          updateData
+        );
+
+        console.log(`Updated signature ${signatureId} with audit trail: ${auditTrailAttachment?.id}, signed: ${signedAttachment?.id}`);
       }
 
       if (uploadedAttachments.length === 0) {

--- a/packages/twenty-server/src/modules/rabbitsign/rabbitsignsignature.service.ts
+++ b/packages/twenty-server/src/modules/rabbitsign/rabbitsignsignature.service.ts
@@ -600,7 +600,6 @@ export class RabbitSignSignatureService extends TypeOrmQueryService<RabbitSignSi
             fullPath: uploadResult.files[0].path,
             type: originalAttachment.type,
             authorId: signature.workspaceMemberId,
-            signatureId: signatureId,
             // Copy the fields from the original attachment to link to the same person/company
             personId: originalAttachment.personId,
             companyId: originalAttachment.companyId,

--- a/packages/twenty-server/src/modules/rabbitsign/standard-objects/rabbitsignsignature.workplace-entity.ts
+++ b/packages/twenty-server/src/modules/rabbitsign/standard-objects/rabbitsignsignature.workplace-entity.ts
@@ -77,6 +77,36 @@ export class RabbitSignSignatureWorkspaceEntity extends BaseWorkspaceEntity {
   attachmentId: string;
 
   @WorkspaceRelation({
+    standardId: RABBIT_SIGN_SIGNATURE_STANDARD_FIELD_IDS.signatureAuditTrailAttachment,
+    type: RelationType.MANY_TO_ONE,
+    label: msg`Signature Audit Trail Download Attachment`,
+    description: msg`The audit trail download attachment for this signature`,
+    icon: 'IconFileDownload',
+    inverseSideTarget: () => AttachmentWorkspaceEntity,
+    inverseSideFieldKey: 'signatureAuditTrailDownload',
+    onDelete: RelationOnDeleteAction.CASCADE,
+  })
+  signatureAuditTrailDownloadAttachment: Relation<AttachmentWorkspaceEntity>;
+
+  @WorkspaceJoinColumn('signatureAuditTrailDownloadAttachment')
+  signatureAuditTrailDownloadAttachmentId: string;
+
+  @WorkspaceRelation({
+    standardId: RABBIT_SIGN_SIGNATURE_STANDARD_FIELD_IDS.signatureSignedAttachment,
+    type: RelationType.MANY_TO_ONE,
+    label: msg`Signature Signed Attachment`,
+    description: msg`The signed attachment for this signature`,
+    icon: 'IconFileCheck',
+    inverseSideTarget: () => AttachmentWorkspaceEntity,
+    inverseSideFieldKey: 'signatureSigned',
+    onDelete: RelationOnDeleteAction.CASCADE,
+  })
+  signatureSignedAttachment: Relation<AttachmentWorkspaceEntity>;
+
+  @WorkspaceJoinColumn('signatureSignedAttachment')
+  signatureSignedAttachmentId: string;
+
+  @WorkspaceRelation({
     standardId: RABBIT_SIGN_KEY_STANDARD_FIELD_IDS.workspaceMember,
     type: RelationType.MANY_TO_ONE,
     label: msg`Workspace Member`,


### PR DESCRIPTION
Now when a document is signed, we will push the signed document and audit trail to our s3.

Along with this, I will track these files as attachments in our system, and create two new relations on the signature to track them:
- "signatureAuditTrailDownloadAttachmentId"
- "signatureSignedAttachmentId"